### PR TITLE
Fix up listener code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,20 @@
 import { useEffect, useState } from 'react'
 
 const query = ([mode]) => `(prefers-color-scheme: ${mode})`
+const darkQuery = window.matchMedia?.(query`dark`)
+const lightQuery = window.matchMedia?.(query`light`)
 
 const usePrefersColorScheme = () => {
+  const isDark = darkQuery?.matches
+  const isLight = lightQuery?.matches
+
   const [preferredColorSchema, setPreferredColorSchema] = useState(
-    'no-preference',
+    isDark ? 'dark' : isLight ? 'light' : 'no-preference',
   )
 
   if (typeof window.matchMedia !== 'function') {
     return preferredColorSchema
   }
-
-  const isDark = window.matchMedia(query`dark`).matches
-  const isLight = window.matchMedia(query`light`).matches
 
   useEffect(() => {
     if (isDark) setPreferredColorSchema('dark')
@@ -21,29 +23,38 @@ const usePrefersColorScheme = () => {
   }, [isDark, isLight])
 
   useEffect(() => {
-    try {
-      window
-        .matchMedia(query`dark`)
-        .addEventListener(
-          'change',
-          ({ matches }) => matches && setPreferredColorSchema('dark'),
-        )
+    if (typeof darkQuery!.addEventListener === 'function') {
+      // In modern browsers MediaQueryList should subclass EventTarget
+      // https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList
+      
+      const darkListener = ({ matches }) => matches && setPreferredColorSchema('dark')
+      const lightListener = ({ matches }) => matches && setPreferredColorSchema('light')
 
-      window
-        .matchMedia(query`light`)
-        .addEventListener(
-          'change',
-          ({ matches }) => matches && setPreferredColorSchema('light'),
-        )
-    } catch (error) {
-      window
-        .matchMedia(query`dark`)
-        .addListener(() => setPreferredColorSchema(isDark ? 'light' : 'dark'))
-    }
+      darkQuery!.addEventListener('change', darkListener)
+      lightQuery!.addEventListener('change', lightListener)
 
-    return () => {
-      window.matchMedia(query`dark`).removeEventListener()
-      window.matchMedia(query`light`).removeEventListener()
+      return () => {
+        darkQuery!.removeEventListener('change', darkListener)
+        lightQuery!.removeEventListener('change', lightListener)
+      }
+    } else {
+      // In some early implementations MediaQueryList existed, but did not
+      // subclass EventTarget
+      
+      // Closing over isDark here would cause it to not update when
+      // `darkQuery.matches` changes
+      const listener = () => setPreferredColorScheme(darkQuery.matches ? 'dark' : lightQuery.matches ? 'light' : 'no-preference'))
+
+      // This is two state updates if a user changes from dark to light, but
+      // both state updates will be consistent and should be batched by React,
+      // resulting in only one re-render
+      darkQuery!.addListener(listener)
+      lightQuery!.addListener(listener)
+      
+      return () => {
+        darkQuery!.removeListener(listener)
+        lightQuery!.removeListener(listener)
+      }
     }
   }, [])
 


### PR DESCRIPTION
1. Cache the MediaQueryList objects, so you don't have to constantly recreate them
2. Set preferredColorScheme correctly from the start, without requiring re-renders
3. Avoid using a 'try-catch-all' statement; probe for features without using exceptions to indicate missing functionality, which also prevents legitimate exceptions from bubbling up (whatever those exceptions may be)
4. Properly remove event listeners depending on which strategy is in use; always cache listener to pass to removeEventListener / removeListener to prevent conflicts with other instances of usePrefersColorScheme
5. In the old/legacy strategy, properly support `no-preference`

This code is untested. In particular I'm not sure if your project supports the null coalescing operator (recent versions of TypeScript should, but it doesn't look like you use that). Overall this should improve the efficiency and accuracy of use-prefers-color-scheme, and make me more comfortable to use it in my project.