### PR TITLE
README tweaks to make the example more dyslexia-friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ import React from 'react'
 import usePrefersColorScheme from 'use-prefers-color-scheme'
 
 const App = () => {
-  const preferredColorSchema = usePrefersColorScheme()
-  const isDarkMode = preferredColorSchema === 'dark'
+  const prefersColorScheme = usePrefersColorScheme()
+  const isDarkMode = prefersColorScheme === 'dark'
 
   return (
     <div>You are using {isDarkMode ? 'Dark Mode 🌚' : 'Light Mode 🌞'}!</div>


### PR DESCRIPTION
This is a trivial change, but I feel the example is rather easy to trip over because of the similarities between:

 - `prefers` vs `preferred`
 - `scheme` vs `schema`

I've updated the example to use only `prefers` and `scheme` throughout (since those are the forms used in the package & repo name).

I am submitting this PR for your consideration since I think it will help people who are prone to dyslexia, but you do you.