### PR TITLE
build(example): fixed react is undefined error

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "react": "file:../node_modules/react",
-    "react-dom": "^18.2.0",
+    "react-dom": "file:../node_modules/react-dom",
     "react-scripts": "^5.0.1",
     "use-prefers-color-scheme": "file:.."
   },


### PR DESCRIPTION
## Old Behavior
Exemple project in `example` will be rendered as white blank page in the browser and console will log errors related to react initialization error.

## New Behavior
Now example project in `example` use `react-dom` dep from parent `node_modules` to avoid errors.
Page renders as expected.